### PR TITLE
How to set and use `cp_application`?

### DIFF
--- a/lib/conf_d.pl
+++ b/lib/conf_d.pl
@@ -78,7 +78,7 @@ another, there are two solutions:
 %	@param	Spec is either the specification of a directory according
 %		to absolute_file_name/3 or a list thereof.  Duplicate
 %		directories are removed.
-%	@tbd	There is a but forking processes in one thread and
+%	@tbd	There is a bug forking processes in one thread and
 %		waiting for X11 in another, which deadlocks in
 %		fork_atfree().  So, we must ensure we have the git
 %		versions in time :-(

--- a/lib/conf_d.pl
+++ b/lib/conf_d.pl
@@ -100,7 +100,7 @@ collect_dirs([H|T], Sols) --> !,
 	collect_dirs(H, Sols),
 	collect_dirs(T, Sols).
 collect_dirs(Spec, Sols) -->
-	findall(Dir, absolute_file_name(Spec, Dir,
+	findall(Dir, absolute_file_name(cp_application(Spec), Dir,
 					[ file_type(directory),
 					  file_errors(fail),
 					  access(read),
@@ -229,16 +229,15 @@ conf_d_member_data(loaded, config_file(F, _, _), B) :-
 %	is the directory holding =|run.pl|=.
 
 set_top_dir :-
+	user:file_search_path(cp_application, _), !.
+set_top_dir :-
 	(   source_file(add_relative_search_path(_,_), File)
 	->  file_directory_name(File, Dir)
 	;   prolog_load_context(directory, Dir)
 	->  true
 	;   working_directory(Dir,Dir)
 	),
-	(   user:file_search_path(cp_application, Dir)
-	->  true
-	;   assert(user:file_search_path(cp_application, Dir))
-	).
+	assert(user:file_search_path(cp_application, Dir)).
 
 %%	conf_d_configuration(+Available, +Enabled, -Configs) is det.
 %


### PR DESCRIPTION
The way I understand this is that an application is free to set `cp_application` (using `user:file_search_path/2`) to paths where configuration information for ClioPatria resides.

`load_conf_d/2` needs to know these paths in order to load subdirectory `config-enabled` in them.  This is why I use `cp_application('config-enabled')` in `collect_dict//2`.

If my above understanding is correct, then there is probably a bug in `set_top_dir/0`: this does not in fact set the ClioPatria path but the path from which the code was loaded (i.e., `prolog_load_context/2`).  The latter need not be the ClioPatria path.  This is why I allow `cp_application` to be set before `set_top_dir/0` is run.

The above relies on my -- possibly incorrect -- understanding of what `cp_application` should denote.