### PR TITLE
Fix dead links to documentation files

### DIFF
--- a/lib/semweb/rdf_optimise.pl
+++ b/lib/semweb/rdf_optimise.pl
@@ -83,7 +83,7 @@ This  algorithm  reaches  optimal  performance  under  quite  reasonable
 assumptions  while  the  planning  overhead   is  very  reasonable.  The
 algorithm is described in "An  optimised   Semantic  Web  query language
 implementation        in        Prolog",          available         from
-http://hcs.science.uva.nl/projects/SWI-Prolog/articles/ICLP05-SeRQL.pdf
+http://www.swi-prolog.org/download/publications/ICLP05-SeRQL.pdf
 
 NOTES:
 

--- a/web/html/welcome.html
+++ b/web/html/welcome.html
@@ -16,10 +16,10 @@ query language.
 <h4>About this server</h4>
 
 This server is built on top of the SWI-Prolog Web infrastructure <a
-href="http://hcs.science.uva.nl/projects/SWI-Prolog/articles/TPLP-plweb.pdf">
+href="http://www.swi-prolog.org/download/publications/TPLP-plweb.pdf">
 (PDF)</a>. It provides a web front-end to the SWI-Prolog Semantic Web
 libraries <a
-href="http://hcs.science.uva.nl/projects/SWI-Prolog/articles/iswc-03.pdf">
+href="http://www.swi-prolog.org/download/publications/iswc-03.pdf">
 (PDF)</a>. Features:
 
 <ul>


### PR DESCRIPTION
I found that the PDF's that are linked from the welcome page gave a 404 error so I replaced them with the correct locations. While working on that I found another reference in a comment in `rdf_optimise.pl` and fixed that too.